### PR TITLE
adapt script to add license headers

### DIFF
--- a/hack/add_license_headers.sh
+++ b/hack/add_license_headers.sh
@@ -1,20 +1,16 @@
 #!/usr/bin/env bash
+
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-
 set -e
 
-echo "> Adding Apache License header to all go files where it is not present"
+echo "> Adding SPDX License header to all go files where it is not present"
 
 # Uses the tool https://github.com/google/addlicense
-YEAR="$(date +%Y)"
 addlicense \
-  -c "SAP SE or an SAP affiliate company" \
-  -y "${YEAR}" \
-  -l apache \
+  -f hack/license_boilerplate.txt \
   -ignore ".idea/**" \
   -ignore ".vscode/**" \
   -ignore "vendor/**" \

--- a/hack/license_boilerplate.txt
+++ b/hack/license_boilerplate.txt
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
-/*
- * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
- *
- * SPDX-License-Identifier: Apache-2.0
- */
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 


### PR DESCRIPTION
**How to categorize this PR?**
Adapt script `hack/add_license_headers.sh` to use SPDX headers defined in file `hack/license_boilerplate.txt` 